### PR TITLE
Fix support for "--doubletGL" argument.

### DIFF
--- a/src/cellsnp.c
+++ b/src/cellsnp.c
@@ -100,7 +100,7 @@ static void gll_set_default(global_settings *gs) {
         gs->nthread = CSP_NTHREAD; gs->tp = NULL; gs->tp_max_open = TP_MAX_OPEN;
         gs->mthread = CSP_NTHREAD; gs->tp_errno = 0; gs->tp_ntry = 0;
         gs->min_count = CSP_MIN_COUNT; gs->min_maf = CSP_MIN_MAF; 
-        gs->double_gl = 0;
+        gs->doublet_gl = 0;
 
         // Read Filtering
         gs->min_len = CSP_MIN_LEN; gs->min_mapq = CSP_MIN_MAPQ;
@@ -434,7 +434,9 @@ int main(int argc, char **argv) {
         {"minMAF", required_argument, NULL, 5},
         {"minMaf", required_argument, NULL, 5},
         {"minmaf", required_argument, NULL, 5},
-        {"doubleGL", no_argument, NULL, 6},
+        {"doubletGL", no_argument, NULL, 6},
+        {"doubletGl", no_argument, NULL, 6},
+        {"doubletgl", no_argument, NULL, 6},
         {"minLEN", required_argument, NULL, 8},
         {"minLen", required_argument, NULL, 8},
         {"minlen", required_argument, NULL, 8},
@@ -515,7 +517,7 @@ int main(int argc, char **argv) {
                     gs.umi_tag = strdup(optarg); break;
             case 4: gs.min_count = atoi(optarg); break;
             case 5: gs.min_maf = atof(optarg); break;
-            case 6: gs.double_gl = 1; break;
+            case 6: gs.doublet_gl = 1; break;
             case 8: gs.min_len = atoi(optarg); break;
             case 9: gs.min_mapq = atoi(optarg); break;
             //case 10: gs.max_flag = atoi(optarg); break;

--- a/src/csp.c
+++ b/src/csp.c
@@ -62,7 +62,7 @@ void gll_setting_print(FILE *fp, global_settings *gs, char *prefix) {
         fprintf(fp, "%scell-tag = %s, umi-tag = %s\n", prefix, gs->cell_tag, gs->umi_tag);
         fprintf(fp, "%snthreads = %d, tp_max_open = %d\n", prefix, gs->nthread, gs->tp_max_open);
         fprintf(fp, "%smthreads = %d, tp_errno = %d, tp_ntry = %d\n", prefix, gs->mthread, gs->tp_errno, gs->tp_ntry);
-        fprintf(fp, "%smin_count = %d, min_maf = %.2f, double_gl = %d\n", prefix, gs->min_count, gs->min_maf, gs->double_gl);
+        fprintf(fp, "%smin_count = %d, min_maf = %.2f, doublet_gl = %d\n", prefix, gs->min_count, gs->min_maf, gs->doublet_gl);
         fprintf(fp, "%smin_len = %d, min_mapq = %d\n", prefix, gs->min_len, gs->min_mapq);
         //fprintf(fp, "%smax_flag = %d\n", prefix, gs->max_flag);
         fprintf(fp, "%srflag_filter = %d, rflag_require = %d\n", prefix, gs->rflag_filter, gs->rflag_require);
@@ -279,7 +279,7 @@ int csp_mplp_stat(csp_mplp_t *mplp, global_settings *gs) {
                         plp->qmat[j][k] += mplp->qvec[k];
                 }
             }
-            if (qual_matrix_to_geno(plp->qmat, plp->bc, mplp->ref_idx, mplp->alt_idx, gs->double_gl, plp->gl, &plp->ngl) < 0)
+            if (qual_matrix_to_geno(plp->qmat, plp->bc, mplp->ref_idx, mplp->alt_idx, gs->doublet_gl, plp->gl, &plp->ngl) < 0)
                 return -1;
         }
     }

--- a/src/csp.h
+++ b/src/csp.h
@@ -133,7 +133,7 @@ struct _gll_settings {
     int tp_max_open;       // Max num of open files for one process
     int min_count;     // Minimum aggragated count.
     double min_maf;    // Minimum minor allele frequency.
-    int double_gl;     // 0 or 1. 1: keep doublet GT likelihood, i.e., GT=0.5 and GT=1.5. 0: not keep.
+    int doublet_gl;    // 0 or 1. 1: keep doublet GT likelihood, i.e., GT=0.5 and GT=1.5. 0: not keep.
     int min_len;       // Minimum mapped length for read filtering.
     int min_mapq;      // Minimum MAPQ for read filtering.
     /* max_flag is deprecated. use rflag_filter and rflag_require instead.


### PR DESCRIPTION
Fix support for "--doubletGL" argument as described in the help. Before this patch the code would check for "--doubleGL" instead.