### PR TITLE
--help/--version should exit with status 0 (and write to stdout)

### DIFF
--- a/src/cellsnp.c
+++ b/src/cellsnp.c
@@ -459,7 +459,7 @@ int main(int argc, char **argv) {
     if (1 == argc) { print_usage(stderr); goto clean; }
     while ((c = getopt_long(argc, argv, "hVs:S:O:R:T:b:i:I:p:f:", lopts, NULL)) != -1) {
         switch (c) {
-            case 'h': print_usage(stderr); goto clean;
+            case 'h': is_ok = 1; print_usage(stdout); goto clean;
             case 'V': printf("%s %s (htslib %s)\n", CSP_NAME, CSP_VERSION, hts_version()); goto clean;
             case 's': 
                     if (gs.in_fns) { str_arr_destroy(gs.in_fns, gs.nin); }

--- a/src/cellsnp.c
+++ b/src/cellsnp.c
@@ -460,7 +460,7 @@ int main(int argc, char **argv) {
     while ((c = getopt_long(argc, argv, "hVs:S:O:R:T:b:i:I:p:f:", lopts, NULL)) != -1) {
         switch (c) {
             case 'h': is_ok = 1; print_usage(stdout); goto clean;
-            case 'V': printf("%s %s (htslib %s)\n", CSP_NAME, CSP_VERSION, hts_version()); goto clean;
+            case 'V': is_ok = 1; printf("%s %s (htslib %s)\n", CSP_NAME, CSP_VERSION, hts_version()); goto clean;
             case 's': 
                     if (gs.in_fns) { str_arr_destroy(gs.in_fns, gs.nin); }
                     if (NULL == (gs.in_fns = hts_readlist(optarg, 0, &gs.nin)) || gs.nin <= 0) {


### PR DESCRIPTION
This changes both `--help` and `--version` to return an exit code of 0, indicating that nothing went wrong with the command, which is true.

It also sends the output of `--help` to stdout instead of stderr, which is the usual behavior for most command-line programs.

This has a few advantages:
1) You can run `cellsnp-lite --version` in a script with `set -o errexit`, without needing to turn off error-catching or swallow it with `|| true`.
2) Users can more easily send the help to a pager, like `cellsnp-lite -h | less`.
3) Less surprising to *nix users.

For reference, sections 4.8.1 and 4.8.2 of the GNU guidelines echo this advice: https://www.gnu.org/prep/standards/standards.html#g_t_002d_002dversion